### PR TITLE
feat: add agent template export into examples

### DIFF
--- a/examples/example-custom.py
+++ b/examples/example-custom.py
@@ -1,5 +1,6 @@
 import os
 from virtuals_sdk import game
+import json
 
 agent = game.Agent(
     api_key=os.environ.get("VIRTUALS_API_KEY"),
@@ -41,3 +42,8 @@ agent.react(
     # specify the task that the agent should do
     task="reply with a music recommendation",
 )
+
+# Export out agent_template.json to upload to game-lite.virtuals.io
+with open('agent_template.json', 'w') as f:
+    agent_dict = json.loads(agent.export())
+    json.dump(agent_dict, f, indent=4)

--- a/examples/example-custom.py
+++ b/examples/example-custom.py
@@ -43,7 +43,8 @@ agent.react(
     task="reply with a music recommendation",
 )
 
-# Export out agent_template.json to upload to game-lite.virtuals.io
-with open('agent_template.json', 'w') as f:
-    agent_dict = json.loads(agent.export())
-    json.dump(agent_dict, f, indent=4)
+# Export out agent.json to upload to game-lite.virtuals.io
+agent.export()
+
+# To deploy the agent
+agent.deploy_twitter()

--- a/examples/example-twitter.py
+++ b/examples/example-twitter.py
@@ -1,5 +1,6 @@
 import os
 from virtuals_sdk import game
+import json
 
 agent = game.Agent(
     api_key=os.environ.get("VIRTUALS_API_KEY"),
@@ -44,3 +45,8 @@ agent.react(
 
 # running simulation module only for platform twitter
 agent.simulate_twitter(session_id="session-twitter")
+
+# Export out agent_template.json to upload to game-lite.virtuals.io
+with open('agent_template.json', 'w') as f:
+    agent_dict = json.loads(agent.export())
+    json.dump(agent_dict, f, indent=4)

--- a/examples/example-twitter.py
+++ b/examples/example-twitter.py
@@ -46,7 +46,8 @@ agent.react(
 # running simulation module only for platform twitter
 agent.simulate_twitter(session_id="session-twitter")
 
-# Export out agent_template.json to upload to game-lite.virtuals.io
-with open('agent_template.json', 'w') as f:
-    agent_dict = json.loads(agent.export())
-    json.dump(agent_dict, f, indent=4)
+# Export out agent.json to upload to game-lite.virtuals.io
+agent.export()
+
+# To deploy the agent
+agent.deploy_twitter()


### PR DESCRIPTION
This allows exporting agent configurations to 'agent_template.json' for easy upload to game-lite.virtuals.io
