### PR TITLE
hotfix: fix simulate function API call

### DIFF
--- a/src/virtuals_sdk/sdk.py
+++ b/src/virtuals_sdk/sdk.py
@@ -38,7 +38,7 @@ class GameSDK:
                     "description": description,
                     "worldInfo": world_info,
                     "functions": functions,
-                    "customFunctions": [x.to_dict() for x in custom_functions]
+                    "customFunctions": [x.toJson() for x in custom_functions]
                 }
             },
             headers={"x-api-key": self.api_key}


### PR DESCRIPTION
 Fixes the API call to the simulate functionality to use toJson() from an old to_dict() implementation